### PR TITLE
Make variable of topic ARN

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -10,16 +10,13 @@ import { randomContract } from "./src/utils";
 dotenv.config();
 
 let services: Services | null = null
-const { AWS_REGION: region, IS_OFFLINE: isOffline } = process.env
+const { AWS_REGION: region, IS_OFFLINE: isOffline, METADATA_TOPIC_ARN:snsTopic } = process.env
 const snsClient = new SNSClient({ region });
-let awsAccountId
-// const snsTopic = `arn:aws:sns:${region}:${accountId}:contract-create-topic`
-// console.log(process.env, region)
+// console.log(snsTopic)
 
 const publishSnsTopic = async (data) => {
   try {
-    if (!isOffline && awsAccountId) {
-      const snsTopic = `arn:aws:sns:${region}:${awsAccountId}:metadata-topic`
+    if (!isOffline && snsTopic) {
       const params: PublishCommandInput = {
         Message: JSON.stringify(data),
         TopicArn: snsTopic
@@ -146,10 +143,6 @@ const defaultResponse: Handler = async (event: any) => {
 }
 
 export const handler: Handler = async (event: any, context: Context) => {
-  if (!isOffline) {
-    awsAccountId = context.invokedFunctionArn.split(':')[4]
-  }
-
   const { routeKey } = event
   switch (routeKey) {
     case 'POST /contract':

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,13 +5,12 @@
 service: stargaze-rarity
 frameworkVersion: '3'
 custom:
-    metadataTopic: metadata-topic #This is the global name of the topic
+    metadataTopic: ${self:service}-${opt:stage, 'dev'}-metadata-topic #This is the global name of the topic
 
 provider:
   name: aws
   region: us-east-1
-  runtime: nodejs14.x
-  
+  runtime: nodejs14.x  
   environment:
     METADATA_TOPIC_ARN: arn:aws:sns:${aws:region}:${aws:accountId}:${self:custom.metadataTopic}
     #postgresql

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,18 +4,22 @@
 #app: stargaze-rarity
 service: stargaze-rarity
 frameworkVersion: '3'
+custom:
+    metadataTopic: metadata-topic #This is the global name of the topic
 
 provider:
   name: aws
   region: us-east-1
   runtime: nodejs14.x
-  environment:     
+  
+  environment:
+    METADATA_TOPIC_ARN: arn:aws:sns:${aws:region}:${aws:accountId}:${self:custom.metadataTopic}
     #postgresql
 #    POSTGRESQL_HOST: ${self:custom.POSTGRESQL.HOST}
 #    POSTGRESQL_PORT: ${self:custom.POSTGRESQL.PORT}
   iamRoleStatements:    
     - Effect: Allow
-      Action: sns:Publish
+      Action: sns:Publish`
       Resource:
         - Ref: MetadataTopic  
 
@@ -41,7 +45,7 @@ functions:
       - sns: 
           arn: 
             Ref: MetadataTopic
-          topicName: metadata-topic
+          topicName: ${self:custom.metadataTopic}
 
 
 plugins:
@@ -54,7 +58,7 @@ resources:
     MetadataTopic:
       Type: AWS::SNS::Topic
       Properties:
-        TopicName: metadata-topic
+        TopicName: ${self:custom.metadataTopic}
       
 #  Resources:
 #    LambdaRole: ${file(./resource/LambdaRole.yml)}


### PR DESCRIPTION
This allows us full control of the topic in the serverless configuration rather than having to hardcode stuff inside the lambda.