### PR TITLE
Add Ranking to meta

### DIFF
--- a/metadata.ts
+++ b/metadata.ts
@@ -12,7 +12,13 @@ export const handler: Handler = async (event: any, context: Context) => {
     const contractId = 'stars18a0pvw326fydfdat5tzyf4t8lhz0v6fyfaujpeg07fwqkygcxejsnp5fac'
     const metadata = await downloadMetadata(contractId)    
     const services = await getServicesSingleton()
-    const output = services.repo.persistIngestedData(contractId, metadata.allTraits, metadata.tokenTraits, metadata.scores)
+    const output = services.repo.persistIngestedData(
+        contractId,
+        metadata.allTraits,
+        metadata.tokenTraits,
+        metadata.scores,
+        metadata.rankings,
+        )
     return {
         statusCode:200,
         body: JSON.stringify(output)

--- a/src/database/entities/tokenMeta.entity.ts
+++ b/src/database/entities/tokenMeta.entity.ts
@@ -29,4 +29,9 @@ export class TokenMeta {
         type: 'numeric'
     })
     score: number;
+
+    @Column({
+        type: 'numeric'
+    })
+    rank: number;
 }

--- a/src/database/migrations/1647597256118-Rankings.ts
+++ b/src/database/migrations/1647597256118-Rankings.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class Rankings1647597256118 implements MigrationInterface {
+    name = 'Rankings1647597256118'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "token_meta" ADD "rank" numeric NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "token_meta" DROP COLUMN "rank"`);
+    }
+
+}

--- a/src/metadata/download.ts
+++ b/src/metadata/download.ts
@@ -10,8 +10,8 @@ interface Trait {
   value: TraitValue;
 }
 
-const getCid=(baseUri:string)=>{
-  return baseUri.replace('ipfs://','')
+const getCid = (baseUri: string) => {
+  return baseUri.replace('ipfs://', '')
 }
 
 export const downloadMetadata = async (sg721Contract: string) => {
@@ -78,7 +78,29 @@ export const downloadMetadata = async (sg721Contract: string) => {
     scores.set(tokenId, score)
   }
 
+  const rankingInfo: { tokenId: string, score: number, numTraits: number, rank: number }[] = [];
+  for (let tokenId of tokenTraits.keys()) {
+    const thisTokenTraits = tokenTraits.get(tokenId)
+    rankingInfo.push({ tokenId, score: scores.get(tokenId), numTraits: thisTokenTraits.length, rank: null })
+  }
+
+  const rankings = new Map<string, number>(
+    rankingInfo
+      .sort((a, b) => {
+        return a.score - b.score || a.numTraits - b.numTraits || parseInt(a.tokenId) - parseInt(b.tokenId)
+      })
+      .reverse()
+      .map((r, i) => [r.tokenId, i + 1] as [string, number])
+  )
+
   // analysis on traits
   console.log('done')
-  return { allTraits, tokenTraits, scores, numTokens, tokenIds: Array.from(tokenTraits.keys()) }
+  return {
+    allTraits,
+    tokenTraits,
+    scores,
+    numTokens,
+    tokenIds: Array.from(tokenTraits.keys()),
+    rankings
+  }
 }


### PR DESCRIPTION
This adds a ranking number to the token meta.
```
npm run typeorm -- migration:runc
```
* You may need to clear current tables

Repull data
```
curl --location --request POST 'http://localhost:3000/metadata-test'
```

Query token
```
curl --location --request GET 'http://localhost:3000/contracts/stars18a0pvw326fydfdat5tzyf4t8lhz0v6fyfaujpeg07fwqkygcxejsnp5fac/rarities/1'
```

Output
```json
{
    "tokenId": "4",
    "meta": {
        "score": "1126.3606823233167",
        "rank": "346"
    },
    "traits": [
        {
            "traitType": "Color Base",
            "value": "Purples and Greens"
        },
        {
            "traitType": "Color Focused",
            "value": "No"
        },
        {
            "traitType": "Dark Interior",
            "value": "No"
        },
        {
            "traitType": "Shape Repetition",
            "value": "Yes"
        },
        {
            "traitType": "Shape Type",
            "value": "Union"
        },
        {
            "traitType": "Color Model",
            "value": "Saturated Depth"
        },
        {
            "traitType": "Repetitions",
            "value": "0.2"
        },
        {
            "traitType": "Seed",
            "value": "1041"
        },
        {
            "traitType": "Color Offset",
            "value": "2.5"
        }
    ]
}
```
