### PR TITLE
Endpoint updates

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -2,7 +2,7 @@ import { PublishCommand, PublishCommandInput, SNSClient } from "@aws-sdk/client-
 import { Handler } from 'aws-lambda';
 import * as dotenv from 'dotenv';
 import { ApiResponse, isOk } from "./src/api/apiResponse";
-import { handleCreateContract, handleReadContract,handleListContracts, handleReadToken, handleListTokens } from "./src/api/controller";
+import { handleCreateContract, handleReadContract, handleListContracts, handleReadToken, handleListTokens } from "./src/api/controller";
 import { Services } from "./src/services";
 
 dotenv.config();
@@ -37,7 +37,7 @@ export const handler: Handler = async (event: any) => {
     const { routeKey } = event
     switch (routeKey) {
       case 'GET /contracts': {
-        const {page, limit} = Object(event.queryStringParameters)
+        const { page, limit } = Object(event.queryStringParameters)
         const response: ApiResponse = await handleListContracts(page, limit)
         return response
       }
@@ -58,7 +58,7 @@ export const handler: Handler = async (event: any) => {
       }
 
       case 'GET /contracts/{contractId}/rarities': {
-        const {page, limit} = Object(event.queryStringParameters)
+        const { page, limit } = Object(event.queryStringParameters)
         const { pathParameters: { contractId } } = event
         const response: ApiResponse = await handleListTokens(contractId, page, limit)
         return response

--- a/api.ts
+++ b/api.ts
@@ -2,7 +2,7 @@ import { PublishCommand, PublishCommandInput, SNSClient } from "@aws-sdk/client-
 import { Handler } from 'aws-lambda';
 import * as dotenv from 'dotenv';
 import { ApiResponse, isOk } from "./src/api/apiResponse";
-import { handleCreateContract, handleReadContract,handleListContracts, handleReadToken } from "./src/api/controller";
+import { handleCreateContract, handleReadContract,handleListContracts, handleReadToken, handleListTokens } from "./src/api/controller";
 import { Services } from "./src/services";
 
 dotenv.config();
@@ -37,7 +37,7 @@ export const handler: Handler = async (event: any) => {
     const { routeKey } = event
     switch (routeKey) {
       case 'GET /contracts': {
-        const {page, limit} = event.queryStringParameters
+        const {page, limit} = Object(event.queryStringParameters)
         const response: ApiResponse = await handleListContracts(page, limit)
         return response
       }
@@ -58,7 +58,10 @@ export const handler: Handler = async (event: any) => {
       }
 
       case 'GET /contracts/{contractId}/rarities': {
-        return {}
+        const {page, limit} = Object(event.queryStringParameters)
+        const { pathParameters: { contractId } } = event
+        const response: ApiResponse = await handleListTokens(contractId, page, limit)
+        return response
       }
 
       case 'GET /contracts/{contractId}/rarities/{tokenId}': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,11 +1929,6 @@
       "integrity": "sha512-d8RK1jg/piCgv5/jD8ta8uJOE10tU8MWExzL1Kf1kOjMaTuL5cW0eZ9ax001SSYa4Ecg6xzZBh/jM4GB7+5OAg==",
       "dev": true
     },
-    "@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
-    },
     "adm-zip": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
@@ -2511,6 +2506,20 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "class-validator": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "requires": {
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
+    },
     "cli-boxes": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
@@ -3002,6 +3011,11 @@
           "dev": true
         }
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
       "version": "1.11.0",
@@ -4689,6 +4703,11 @@
         "bech32": "^1.1.4",
         "ripemd160": "^2.0.2"
       }
+    },
+    "libphonenumber-js": {
+      "version": "1.9.50",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.50.tgz",
+      "integrity": "sha512-cCzQPChw2XbordcO2LKiw5Htx5leHVfFk/EXkxNHqJfFo7Fndcb1kF5wPJpc316vCJhhikedYnVysMh3Sc7Ocw=="
     },
     "libsodium": {
       "version": "0.7.9",
@@ -6831,27 +6850,27 @@
       }
     },
     "typeorm": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-      "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.0.tgz",
+      "integrity": "sha512-fGhJql31DRyxT0bxcjD5kAf9hz+aUppp90M93GmlRlCfHq+qKhY70eCEreAgjrlAYmZkfEgDcyMHpcAfrtCe7A==",
       "requires": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.0",
         "cli-highlight": "^2.1.11",
-        "debug": "^4.3.1",
-        "dotenv": "^8.2.0",
-        "glob": "^7.1.6",
-        "js-yaml": "^4.0.0",
+        "date-fns": "^2.28.0",
+        "debug": "^4.3.3",
+        "dotenv": "^16.0.0",
+        "glob": "^7.2.0",
+        "js-yaml": "^4.1.0",
         "mkdirp": "^1.0.4",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.1.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23",
-        "yargs": "^17.0.1",
-        "zen-observable-ts": "^1.0.0"
+        "yargs": "^17.3.1"
       },
       "dependencies": {
         "buffer": {
@@ -6862,11 +6881,6 @@
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
           }
-        },
-        "dotenv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
         },
         "xml2js": {
           "version": "0.4.23",
@@ -7024,6 +7038,11 @@
       "requires": {
         "builtins": "^1.0.3"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "velocityjs": {
       "version": "2.0.6",
@@ -7230,20 +7249,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
-    },
-    "zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "requires": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
-      }
     },
     "zip-stream": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "@cosmjs/cli": "^0.27.1",
     "@types/dotenv": "^8.2.0",
     "class-transformer": "^0.5.1",
+    "class-validator": "^0.13.2",
     "cosmwasm": "^1.0.3",
     "fetch-retry": "^5.0.2",
     "node-fetch": "^2.6.7",
     "pg": "^8.7.3",
     "tiny-async-pool": "^1.2.0",
-    "typeorm": "^0.2.45"
+    "typeorm": "^0.3.0"
   },
   "scripts": {
     "start": "sls offline --printOutput",

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -46,7 +46,7 @@ const handleListTokens = async (contractId, page, limit) => {
     })
 }
 
-const handleReadToken = async(contractId, tokenId) => {
+const handleReadToken = async (contractId, tokenId) => {
     return handleReturn(200, async () => {
         return await readToken(contractId, tokenId)
     })

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -1,6 +1,9 @@
 
-import { instanceToPlain } from "class-transformer";
+import { instanceToPlain, plainToClass } from "class-transformer";
 import { ApiResponse } from "./apiResponse";
+import { SG721Model } from "./models/sg721.model";
+import { SG721SimpleModel } from "./models/sg721Simple.model";
+import { TokenModel } from "./models/token.model";
 import { createContract, readContract, listContracts, readToken, listTokens } from "./service";
 
 const toJson = (obj: any): string => JSON.stringify(instanceToPlain(obj))
@@ -24,31 +27,36 @@ const handleReturn = async (statusCode: number, callback: () => any): Promise<Ap
 
 const handleCreateContract = async (contractId): Promise<ApiResponse> => {
     return handleReturn(201, async () => {
-        return await createContract(contractId)
+        const contract = await createContract(contractId)
+        return plainToClass(SG721SimpleModel, contract)
     })
 }
 
 const handleReadContract = async (contractId) => {
     return handleReturn(200, async () => {
-        return await readContract(contractId)
+        const contract = await readContract(contractId)
+        return plainToClass(SG721Model, contract)
     })
 }
 
 const handleListContracts = async (page, limit) => {
     return handleReturn(200, async () => {
-        return await listContracts(page, limit)
+        const contracts = await listContracts(page, limit)
+        return contracts.map((c) => plainToClass(SG721SimpleModel, c))
     })
 }
 
 const handleListTokens = async (contractId, page, limit) => {
     return handleReturn(200, async () => {
-        return await listTokens(contractId, page, limit)
+        const tokens = await listTokens(contractId, page, limit)
+        return tokens.map((t) => plainToClass(TokenModel, t))
     })
 }
 
 const handleReadToken = async (contractId, tokenId) => {
     return handleReturn(200, async () => {
-        return await readToken(contractId, tokenId)
+        const token = await readToken(contractId, tokenId)
+        return plainToClass(TokenModel, token)
     })
 }
 

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -1,7 +1,7 @@
 
 import { instanceToPlain } from "class-transformer";
 import { ApiResponse } from "./apiResponse";
-import { createContract, readContract, listContracts, readToken } from "./service";
+import { createContract, readContract, listContracts, readToken, listTokens } from "./service";
 
 const toJson = (obj: any): string => JSON.stringify(instanceToPlain(obj))
 
@@ -40,6 +40,12 @@ const handleListContracts = async (page, limit) => {
     })
 }
 
+const handleListTokens = async (contractId, page, limit) => {
+    return handleReturn(200, async () => {
+        return await listTokens(contractId, page, limit)
+    })
+}
+
 const handleReadToken = async(contractId, tokenId) => {
     return handleReturn(200, async () => {
         return await readToken(contractId, tokenId)
@@ -50,5 +56,6 @@ export {
     handleCreateContract,
     handleReadContract,
     handleListContracts,
-    handleReadToken
+    handleReadToken,
+    handleListTokens
 };

--- a/src/api/models/sg721.model.ts
+++ b/src/api/models/sg721.model.ts
@@ -1,0 +1,28 @@
+import { Exclude, Expose, Transform, Type } from "class-transformer";
+import { SG721MetaModel } from "./sg721Meta.model";
+import { SG721TraitModel } from "./sg721Trait.model";
+import { TokenModel } from "./token.model";
+
+export class SG721Model {
+
+  @Exclude()
+  id: number;
+
+  contract: string; // Probably want to validate that it is a stars... address    
+
+  createdAt: Date;
+
+  @Expose()
+  @Transform(({obj}) => obj.meta.count, {toClassOnly: true})
+  count: number;
+
+  @Type(() => SG721TraitModel)
+  traits: SG721TraitModel[];
+
+  @Type(() => TokenModel)
+  tokens: TokenModel[];
+
+  @Exclude()
+  @Type(() => SG721MetaModel)
+  meta: SG721MetaModel;
+}

--- a/src/api/models/sg721.model.ts
+++ b/src/api/models/sg721.model.ts
@@ -13,6 +13,7 @@ export class SG721Model {
   createdAt: Date;
 
   @Expose()
+  @Type(() => Number)
   @Transform(({obj}) => obj.meta.count, {toClassOnly: true})
   count: number;
 

--- a/src/api/models/sg721Meta.model.ts
+++ b/src/api/models/sg721Meta.model.ts
@@ -1,0 +1,16 @@
+import { Exclude } from 'class-transformer';
+import { SG721Model } from './sg721.model';
+
+export class SG721MetaModel {
+
+    @Exclude()
+    id: number;
+
+    @Exclude()
+    createdAt: Date;
+
+    @Exclude()
+    contract: SG721Model;
+
+    count: number;
+}

--- a/src/api/models/sg721Simple.model.ts
+++ b/src/api/models/sg721Simple.model.ts
@@ -1,0 +1,29 @@
+import { Exclude, Expose, Transform, Type } from "class-transformer";
+import { SG721MetaModel } from "./sg721Meta.model";
+import { SG721TraitModel } from "./sg721Trait.model";
+import { TokenModel } from "./token.model";
+
+export class SG721SimpleModel {
+
+  @Exclude()
+  id: number;
+
+  contract: string; // Probably want to validate that it is a stars... address    
+
+  createdAt: Date;
+
+  @Expose()
+  @Transform(({obj}) => obj.meta.count, {toClassOnly: true})
+  count: number;
+
+  @Exclude()
+  traits: SG721TraitModel[];
+
+  @Exclude()
+  @Type(() => TokenModel)
+  tokens: TokenModel[];
+
+  @Exclude()
+  @Type(() => SG721MetaModel)
+  meta: SG721MetaModel;
+}

--- a/src/api/models/sg721Simple.model.ts
+++ b/src/api/models/sg721Simple.model.ts
@@ -13,6 +13,7 @@ export class SG721SimpleModel {
   createdAt: Date;
 
   @Expose()
+  @Type(() => Number)
   @Transform(({obj}) => obj.meta.count, {toClassOnly: true})
   count: number;
 

--- a/src/api/models/sg721Trait.model.ts
+++ b/src/api/models/sg721Trait.model.ts
@@ -1,0 +1,31 @@
+import { Exclude } from "class-transformer";
+import { SG721Model } from "./sg721.model";
+
+export class SG721TraitModel {
+
+  @Exclude()
+  id: number;
+
+  @Exclude()
+  createdAt: Date;
+
+  @Exclude()
+  contract: SG721Model;
+
+  traitType: string;
+
+  // Might want to support this in the future
+  //   @Column({
+  //     type: "varchar",
+  //     length: 1024,
+  //     name: 'display_type'
+  //   })
+  //   displayType: string; 
+  
+
+  value: any;
+
+  count: number
+
+  tokenTraits: SG721TraitModel[];
+}

--- a/src/api/models/token.model.ts
+++ b/src/api/models/token.model.ts
@@ -15,10 +15,12 @@ export class TokenModel {
     tokenId: string;
 
     @Expose()
+    @Type(() => Number)
     @Transform(({obj}) => obj.meta.score, {toClassOnly: true})
     score: number;
 
     @Expose()
+    @Type(() => Number)
     @Transform(({obj}) => obj.meta.rank, {toClassOnly: true})
     rank: number;
 

--- a/src/api/models/token.model.ts
+++ b/src/api/models/token.model.ts
@@ -1,0 +1,38 @@
+import { Exclude, Expose, Transform, Type } from 'class-transformer';
+import { TokenMetaModel } from './tokenMeta.model';
+import { TokenTraitModel } from './tokenTrait.model';
+
+// This allows us to separate the JSON output
+// from the DB models
+export class TokenModel {
+
+    @Exclude()
+    id: number;
+
+    @Exclude()
+    createdAt: Date;
+
+    tokenId: string;
+
+    @Expose()
+    @Transform(({obj}) => obj.meta.score, {toClassOnly: true})
+    score: number;
+
+    @Expose()
+    @Transform(({obj}) => obj.meta.rank, {toClassOnly: true})
+    rank: number;
+
+    @Exclude()
+    @Type(() => TokenMetaModel)
+    meta: TokenMetaModel;
+
+    @Exclude()
+    contract: any;
+
+    @Exclude()
+    contract_address: string;
+
+    @Type(() => TokenTraitModel)
+    traits: TokenTraitModel[];
+
+}

--- a/src/api/models/token.model.ts
+++ b/src/api/models/token.model.ts
@@ -1,4 +1,5 @@
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
+import { SG721Model } from './sg721.model';
 import { TokenMetaModel } from './tokenMeta.model';
 import { TokenTraitModel } from './tokenTrait.model';
 
@@ -24,12 +25,18 @@ export class TokenModel {
     @Transform(({obj}) => obj.meta.rank, {toClassOnly: true})
     rank: number;
 
+    @Expose()
+    @Type(() => Number)
+    @Transform(({obj}) => obj.contract.meta.count, {toClassOnly: true})
+    total: number;
+
     @Exclude()
     @Type(() => TokenMetaModel)
     meta: TokenMetaModel;
 
     @Exclude()
-    contract: any;
+    @Type(() => SG721Model)
+    contract: SG721Model;
 
     @Exclude()
     contract_address: string;

--- a/src/api/models/tokenMeta.model.ts
+++ b/src/api/models/tokenMeta.model.ts
@@ -1,0 +1,22 @@
+import { Exclude } from 'class-transformer';
+import { SG721Model } from './sg721.model';
+import { TokenModel } from './token.model';
+
+export class TokenMetaModel {
+
+    @Exclude()
+    id: number;
+
+    @Exclude()
+    createdAt: Date;
+
+    @Exclude()
+    contract: SG721Model;
+
+    @Exclude()
+    token: TokenModel;
+
+    score: number;
+
+    rank: number;
+}

--- a/src/api/models/tokenTrait.model.ts
+++ b/src/api/models/tokenTrait.model.ts
@@ -1,0 +1,33 @@
+
+import { Exclude, Expose, Transform, Type } from "class-transformer";
+import { SG721Model } from "./sg721.model";
+import { SG721TraitModel } from "./sg721Trait.model";
+import { TokenModel } from "./token.model";
+
+export class TokenTraitModel {
+
+    @Exclude()
+    id: number;
+
+    @Exclude()
+    createdAt: Date;
+
+    @Exclude()
+    contract: SG721Model;
+
+    @Exclude()
+    token: TokenModel;
+
+    traitType: string;
+
+    value: any;
+
+    @Exclude()
+    @Type(() => SG721TraitModel)
+    trait: SG721TraitModel;
+
+    @Expose()
+    @Transform(({obj}) => obj.trait.count, {toClassOnly: true})
+    count: number
+
+}

--- a/src/api/models/tokenTrait.model.ts
+++ b/src/api/models/tokenTrait.model.ts
@@ -27,6 +27,7 @@ export class TokenTraitModel {
     trait: SG721TraitModel;
 
     @Expose()
+    @Type(() => Number)
     @Transform(({obj}) => obj.trait.count, {toClassOnly: true})
     count: number
 

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -1,4 +1,3 @@
-import { instanceToPlain } from "class-transformer";
 import { SG721 } from "../database/entities/sg721.entity";
 import { Token } from "../database/entities/token.entity";
 import { getServicesSingleton, Services } from "../services";
@@ -32,6 +31,16 @@ const listContracts = async (page: number | undefined, limit: number | undefined
     return services.repo.getContracts(take, skip)
 }
 
+
+const listTokens = async (contractId: string, page: number | undefined, limit: number | undefined): Promise<Token[]> => {
+    const take = limit && limit <= pageLimit ? limit : pageLimit
+    const skip = page && page > 1 ? (page - 1) * take : 0
+    if (!services) {
+        services = await getServicesSingleton()
+    }
+    return services.repo.getTokens(contractId, take, skip)
+}
+
 const readToken = async (contractId: string, tokenId: string): Promise<Token> => {
     if (!services) {
         services = await getServicesSingleton()
@@ -44,5 +53,6 @@ export {
     createContract,
     readContract,
     listContracts,
-    readToken
+    readToken,
+    listTokens
 }

--- a/src/database/entities/sg721.entity.ts
+++ b/src/database/entities/sg721.entity.ts
@@ -1,6 +1,5 @@
 import { Column, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import { SG721Trait } from "./sg721Trait.entity";
-import { Exclude } from "class-transformer";
 import { Token } from "./token.entity";
 import { SG721Meta } from "./sg721Meta.entity";
 
@@ -8,7 +7,6 @@ import { SG721Meta } from "./sg721Meta.entity";
 @Entity('sg721s')
 export class SG721 {
 
-  @Exclude()
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/database/entities/sg721.entity.ts
+++ b/src/database/entities/sg721.entity.ts
@@ -14,8 +14,7 @@ export class SG721 {
 
   @Column({
     type: "varchar",
-    length: 64,
-    unique: true
+    length: 64
   })
   contract: string; // Probably want to validate that it is a stars... address    
 

--- a/src/database/entities/sg721Meta.entity.ts
+++ b/src/database/entities/sg721Meta.entity.ts
@@ -1,4 +1,3 @@
-import { Exclude } from 'class-transformer';
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { SG721 } from './sg721.entity';
 
@@ -6,15 +5,12 @@ import { SG721 } from './sg721.entity';
 @Unique(['contract'])
 export class SG721Meta {
 
-    @Exclude()
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Exclude()
     @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
     createdAt: Date;
 
-    @Exclude()
     @ManyToOne(() => SG721)
     @JoinColumn({ name: 'contract_id' })
     contract: SG721;

--- a/src/database/entities/sg721Meta.entity.ts
+++ b/src/database/entities/sg721Meta.entity.ts
@@ -16,7 +16,7 @@ export class SG721Meta {
 
     @Exclude()
     @ManyToOne(() => SG721)
-    @JoinColumn({ name: 'contract_id'})
+    @JoinColumn({ name: 'contract_id' })
     contract: SG721;
 
     @Column({

--- a/src/database/entities/sg721Trait.entity.ts
+++ b/src/database/entities/sg721Trait.entity.ts
@@ -1,7 +1,8 @@
-import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from "typeorm";
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, Unique } from "typeorm";
 import { SG721 } from "./sg721.entity";
 import { TraitValue } from "../utils/types";
 import { Exclude } from "class-transformer";
+import { TokenTrait } from "./tokenTrait.entity";
 
 @Entity('sg721_traits')
 @Unique(['contract', 'traitType', 'value'])
@@ -17,7 +18,7 @@ export class SG721Trait {
 
   @Exclude()
   @ManyToOne(() => SG721, contract => contract.traits)
-  @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
+  @JoinColumn({ name: 'contract_id'})
   contract: SG721;
 
   @Column({
@@ -46,4 +47,8 @@ export class SG721Trait {
     type: "integer"
   })
   count: number
+
+
+  @OneToMany(() => TokenTrait, tokenTrait => tokenTrait.trait)
+  tokenTraits: SG721Trait[];
 }

--- a/src/database/entities/sg721Trait.entity.ts
+++ b/src/database/entities/sg721Trait.entity.ts
@@ -18,7 +18,7 @@ export class SG721Trait {
 
   @Exclude()
   @ManyToOne(() => SG721, contract => contract.traits)
-  @JoinColumn({ name: 'contract_id'})
+  @JoinColumn({ name: 'contract_id' })
   contract: SG721;
 
   @Column({

--- a/src/database/entities/sg721Trait.entity.ts
+++ b/src/database/entities/sg721Trait.entity.ts
@@ -1,27 +1,22 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, Unique } from "typeorm";
 import { SG721 } from "./sg721.entity";
 import { TraitValue } from "../utils/types";
-import { Exclude } from "class-transformer";
 import { TokenTrait } from "./tokenTrait.entity";
 
 @Entity('sg721_traits')
 @Unique(['contract', 'traitType', 'value'])
 export class SG721Trait {
 
-  @Exclude()
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Exclude()
   @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
   createdAt: Date;
 
-  @Exclude()
   @ManyToOne(() => SG721, contract => contract.traits)
   @JoinColumn({ name: 'contract_id' })
   contract: SG721;
 
-  @Exclude()
   @Column({
     type: "varchar",
     length: 1024,
@@ -37,7 +32,6 @@ export class SG721Trait {
   //   })
   //   displayType: string; 
   
-  @Exclude()
   @Column({
     type: "jsonb",
     array: false,

--- a/src/database/entities/sg721Trait.entity.ts
+++ b/src/database/entities/sg721Trait.entity.ts
@@ -21,6 +21,7 @@ export class SG721Trait {
   @JoinColumn({ name: 'contract_id' })
   contract: SG721;
 
+  @Exclude()
   @Column({
     type: "varchar",
     length: 1024,
@@ -35,7 +36,8 @@ export class SG721Trait {
   //     name: 'display_type'
   //   })
   //   displayType: string; 
-
+  
+  @Exclude()
   @Column({
     type: "jsonb",
     array: false,

--- a/src/database/entities/sg721Trait.entity.ts
+++ b/src/database/entities/sg721Trait.entity.ts
@@ -4,7 +4,7 @@ import { TraitValue } from "../utils/types";
 import { Exclude } from "class-transformer";
 
 @Entity('sg721_traits')
-// @Unique(['contract', 'traitType', 'value']) // this doesn't seem to work with jsonb values
+@Unique(['contract', 'traitType', 'value'])
 export class SG721Trait {
 
   @Exclude()
@@ -17,7 +17,7 @@ export class SG721Trait {
 
   @Exclude()
   @ManyToOne(() => SG721, contract => contract.traits)
-  @JoinColumn({ name: 'contract_id' })
+  @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
   contract: SG721;
 
   @Column({

--- a/src/database/entities/token.entity.ts
+++ b/src/database/entities/token.entity.ts
@@ -27,8 +27,15 @@ export class Token {
     meta: TokenMeta;
 
     @ManyToOne(() => SG721, contract => contract.tokens)
-    @JoinColumn({ name: 'contract_id', referencedColumnName: 'contract' })
+    @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
     contract: SG721;
+
+    // Keep a normalized field of contract address for fast lookups
+    @Column({
+        type: "varchar",
+        length: 64
+    })
+    contract_address: string;
 
     @OneToMany(() => TokenTrait, trait => trait.token, { cascade: true })
     traits: TokenTrait[];

--- a/src/database/entities/token.entity.ts
+++ b/src/database/entities/token.entity.ts
@@ -1,4 +1,3 @@
-import { Exclude, Expose } from 'class-transformer';
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { SG721 } from './sg721.entity';
 import { TokenMeta } from './tokenMeta.entity';
@@ -8,11 +7,9 @@ import { TokenTrait } from './tokenTrait.entity';
 @Unique(['tokenId', 'contract'])
 export class Token {
 
-    @Exclude()
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Exclude()
     @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
     createdAt: Date;
 
@@ -31,7 +28,6 @@ export class Token {
     contract: SG721;
 
     // Keep a normalized field of contract address for fast lookups
-    @Exclude()
     @Column({
         type: "varchar",
         length: 64

--- a/src/database/entities/token.entity.ts
+++ b/src/database/entities/token.entity.ts
@@ -26,12 +26,12 @@ export class Token {
     @OneToOne(() => TokenMeta, meta => meta.token, { cascade: true })
     meta: TokenMeta;
 
-    @Exclude()
     @ManyToOne(() => SG721, contract => contract.tokens)
-    @JoinColumn({ name: 'contract_id' })
+    @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
     contract: SG721;
 
     // Keep a normalized field of contract address for fast lookups
+    @Exclude()
     @Column({
         type: "varchar",
         length: 64

--- a/src/database/entities/token.entity.ts
+++ b/src/database/entities/token.entity.ts
@@ -27,7 +27,7 @@ export class Token {
     meta: TokenMeta;
 
     @ManyToOne(() => SG721, contract => contract.tokens)
-    @JoinColumn({ name: 'contract_id'})
+    @JoinColumn({ name: 'contract_id' })
     contract: SG721;
 
     // Keep a normalized field of contract address for fast lookups

--- a/src/database/entities/token.entity.ts
+++ b/src/database/entities/token.entity.ts
@@ -26,6 +26,7 @@ export class Token {
     @OneToOne(() => TokenMeta, meta => meta.token, { cascade: true })
     meta: TokenMeta;
 
+    @Exclude()
     @ManyToOne(() => SG721, contract => contract.tokens)
     @JoinColumn({ name: 'contract_id' })
     contract: SG721;

--- a/src/database/entities/token.entity.ts
+++ b/src/database/entities/token.entity.ts
@@ -27,7 +27,7 @@ export class Token {
     meta: TokenMeta;
 
     @ManyToOne(() => SG721, contract => contract.tokens)
-    @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
+    @JoinColumn({ name: 'contract_id'})
     contract: SG721;
 
     // Keep a normalized field of contract address for fast lookups

--- a/src/database/entities/tokenMeta.entity.ts
+++ b/src/database/entities/tokenMeta.entity.ts
@@ -17,12 +17,12 @@ export class TokenMeta {
 
     @Exclude()
     @ManyToOne(() => SG721)
-    @JoinColumn({ name: 'contract_id'})
+    @JoinColumn({ name: 'contract_id' })
     contract: SG721;
 
     @Exclude()
     @OneToOne(() => Token, token => token.meta)
-    @JoinColumn({ name: 'token_id'})
+    @JoinColumn({ name: 'token_id' })
     token: Token;
 
     @Column({

--- a/src/database/entities/tokenMeta.entity.ts
+++ b/src/database/entities/tokenMeta.entity.ts
@@ -1,4 +1,3 @@
-import { Exclude } from 'class-transformer';
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { SG721 } from './sg721.entity';
 import { Token } from './token.entity';
@@ -7,20 +6,16 @@ import { Token } from './token.entity';
 @Unique(['token', 'contract'])
 export class TokenMeta {
 
-    @Exclude()
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Exclude()
     @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
     createdAt: Date;
 
-    @Exclude()
     @ManyToOne(() => SG721)
     @JoinColumn({ name: 'contract_id' })
     contract: SG721;
 
-    @Exclude()
     @OneToOne(() => Token, token => token.meta)
     @JoinColumn({ name: 'token_id' })
     token: Token;

--- a/src/database/entities/tokenTrait.entity.ts
+++ b/src/database/entities/tokenTrait.entity.ts
@@ -22,7 +22,7 @@ export class TokenTrait {
 
     @Exclude()
     @ManyToOne(() => SG721)
-    @JoinColumn({ name: 'contract_id'})
+    @JoinColumn({ name: 'contract_id' })
     contract: SG721;
 
     @Exclude()
@@ -52,8 +52,8 @@ export class TokenTrait {
     //   })
     //   displayType: string; 
 
-    @ManyToOne(() => SG721Trait, sg721Trait => sg721Trait.tokenTraits)      
-    @JoinColumn({ name: 'trait_id' }) 
+    @ManyToOne(() => SG721Trait, sg721Trait => sg721Trait.tokenTraits)
+    @JoinColumn({ name: 'trait_id' })
     trait: SG721Trait;
 
 }

--- a/src/database/entities/tokenTrait.entity.ts
+++ b/src/database/entities/tokenTrait.entity.ts
@@ -3,7 +3,6 @@ import { SG721 } from "./sg721.entity";
 import { Token } from "./token.entity";
 import { SG721Trait } from "./sg721Trait.entity";
 import { TraitValue } from "../utils/types";
-import { Exclude } from "class-transformer";
 
 /**
  * Trying to follow: https://docs.opensea.io/docs/metadata-standards
@@ -12,20 +11,16 @@ import { Exclude } from "class-transformer";
 @Unique(['contract', 'token', 'traitType'])
 export class TokenTrait {
 
-    @Exclude()
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Exclude()
     @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
     createdAt: Date;
 
-    @Exclude()
     @ManyToOne(() => SG721)
     @JoinColumn({ name: 'contract_id' })
     contract: SG721;
 
-    @Exclude()
     @ManyToOne(() => Token, token => token.traits)
     @JoinColumn({ name: 'token_id' })
     token: Token;

--- a/src/database/entities/tokenTrait.entity.ts
+++ b/src/database/entities/tokenTrait.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn, Unique } from "typeorm";
 import { SG721 } from "./sg721.entity";
 import { Token } from "./token.entity";
 import { SG721Trait } from "./sg721Trait.entity";
@@ -9,6 +9,7 @@ import { Exclude } from "class-transformer";
  * Trying to follow: https://docs.opensea.io/docs/metadata-standards
  */
 @Entity('token_traits')
+@Unique(['contract', 'traitType', 'value'])
 export class TokenTrait {
 
     @Exclude()
@@ -21,7 +22,7 @@ export class TokenTrait {
 
     @Exclude()
     @ManyToOne(() => SG721)
-    @JoinColumn({ name: 'contract_id' })
+    @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
     contract: SG721;
 
     @Exclude()
@@ -40,9 +41,8 @@ export class TokenTrait {
         type: "jsonb",
         array: false,
         nullable: true
-      })
-      value: TraitValue;
-
+    })
+    value: TraitValue;
 
     // Might want to support this in the future
     //   @Column({
@@ -53,7 +53,11 @@ export class TokenTrait {
     //   displayType: string; 
 
     @OneToOne(() => SG721Trait)
-    @JoinColumn({ name: 'trait_id' })
+    @JoinColumn([
+        { name: 'contract_id', referencedColumnName: 'contract' },
+        { name: 'trait_type', referencedColumnName: 'traitType' },
+        { name: 'value', referencedColumnName: 'value' }
+    ])
     trait: SG721Trait;
 
 }

--- a/src/database/entities/tokenTrait.entity.ts
+++ b/src/database/entities/tokenTrait.entity.ts
@@ -22,7 +22,7 @@ export class TokenTrait {
 
     @Exclude()
     @ManyToOne(() => SG721)
-    @JoinColumn({ name: 'contract_id', referencedColumnName: 'id' })
+    @JoinColumn({ name: 'contract_id'})
     contract: SG721;
 
     @Exclude()
@@ -52,12 +52,8 @@ export class TokenTrait {
     //   })
     //   displayType: string; 
 
-    @OneToOne(() => SG721Trait)
-    @JoinColumn([
-        { name: 'contract_id', referencedColumnName: 'contract' },
-        { name: 'trait_type', referencedColumnName: 'traitType' },
-        { name: 'value', referencedColumnName: 'value' }
-    ])
+    @ManyToOne(() => SG721Trait, sg721Trait => sg721Trait.tokenTraits)      
+    @JoinColumn({ name: 'trait_id' }) 
     trait: SG721Trait;
 
 }

--- a/src/database/entities/tokenTrait.entity.ts
+++ b/src/database/entities/tokenTrait.entity.ts
@@ -9,7 +9,7 @@ import { Exclude } from "class-transformer";
  * Trying to follow: https://docs.opensea.io/docs/metadata-standards
  */
 @Entity('token_traits')
-@Unique(['contract', 'traitType', 'value'])
+@Unique(['contract', 'token', 'traitType'])
 export class TokenTrait {
 
     @Exclude()

--- a/src/database/migrations/1647555340241-TokenSchema.ts
+++ b/src/database/migrations/1647555340241-TokenSchema.ts
@@ -34,6 +34,7 @@ export class TokenSchema1647555340241 implements MigrationInterface {
         await queryRunner.query(`DROP TABLE "token_traits"`);
         await queryRunner.query(`DROP TABLE "token_meta"`);
         await queryRunner.query(`DROP TABLE "sg721_traits"`);
+        await queryRunner.query(`drop table if exists "traits"`);
         await queryRunner.query(`create table traits
         (
             id          SERIAL PRIMARY KEY,

--- a/src/database/migrations/1647631571890-TokenContract.ts
+++ b/src/database/migrations/1647631571890-TokenContract.ts
@@ -1,0 +1,38 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class TokenContract1647631571890 implements MigrationInterface {
+    name = 'TokenContract1647631571890'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tokens" ADD "contract_address" character varying(64) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP CONSTRAINT "FK_a09a820642da185ae817a51fc0e"`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP CONSTRAINT "UQ_d1f7114d5c02feb34d82f28112a"`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP COLUMN "contract_id"`);
+        await queryRunner.query(`ALTER TABLE "tokens" ADD "contract_id" integer`);
+        await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "FK_13ac72155a579842fae45cbe80b"`);
+        await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "REL_13ac72155a579842fae45cbe80"`);
+        await queryRunner.query(`ALTER TABLE "sg721s" DROP CONSTRAINT "sg721s_contract_key"`);
+        await queryRunner.query(`ALTER TABLE "tokens" ADD CONSTRAINT "UQ_d1f7114d5c02feb34d82f28112a" UNIQUE ("token_id", "contract_id")`);
+        await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "UQ_2efe151cf3bf9b7872486989da3" UNIQUE ("contract_id", "trait_type", "value")`);
+        await queryRunner.query(`ALTER TABLE "sg721_traits" ADD CONSTRAINT "UQ_b40f9903413f8220b55d7a5f05c" UNIQUE ("contract_id", "trait_type", "value")`);
+        await queryRunner.query(`ALTER TABLE "tokens" ADD CONSTRAINT "FK_a09a820642da185ae817a51fc0e" FOREIGN KEY ("contract_id") REFERENCES "sg721s"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "FK_13ac72155a579842fae45cbe80b" FOREIGN KEY ("trait_id") REFERENCES "sg721_traits"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "FK_13ac72155a579842fae45cbe80b"`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP CONSTRAINT "FK_a09a820642da185ae817a51fc0e"`);
+        await queryRunner.query(`ALTER TABLE "sg721_traits" DROP CONSTRAINT "UQ_b40f9903413f8220b55d7a5f05c"`);
+        await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "UQ_2efe151cf3bf9b7872486989da3"`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP CONSTRAINT "UQ_d1f7114d5c02feb34d82f28112a"`);
+        await queryRunner.query(`ALTER TABLE "sg721s" ADD CONSTRAINT "sg721s_contract_key" UNIQUE ("contract")`);
+        await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "REL_13ac72155a579842fae45cbe80" UNIQUE ("trait_id")`);
+        await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "FK_13ac72155a579842fae45cbe80b" FOREIGN KEY ("trait_id") REFERENCES "sg721_traits"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP COLUMN "contract_id"`);
+        await queryRunner.query(`ALTER TABLE "tokens" ADD "contract_id" character varying(64)`);
+        await queryRunner.query(`ALTER TABLE "tokens" ADD CONSTRAINT "UQ_d1f7114d5c02feb34d82f28112a" UNIQUE ("token_id", "contract_id")`);
+        await queryRunner.query(`ALTER TABLE "tokens" ADD CONSTRAINT "FK_a09a820642da185ae817a51fc0e" FOREIGN KEY ("contract_id") REFERENCES "sg721s"("contract") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "tokens" DROP COLUMN "contract_address"`);
+    }
+
+}

--- a/src/database/migrations/1647633327975-TokenContract.ts
+++ b/src/database/migrations/1647633327975-TokenContract.ts
@@ -1,7 +1,7 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class TokenContract1647631571890 implements MigrationInterface {
-    name = 'TokenContract1647631571890'
+export class TokenContract1647633327975 implements MigrationInterface {
+    name = 'TokenContract1647633327975'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "tokens" ADD "contract_address" character varying(64) NOT NULL`);
@@ -13,7 +13,7 @@ export class TokenContract1647631571890 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "REL_13ac72155a579842fae45cbe80"`);
         await queryRunner.query(`ALTER TABLE "sg721s" DROP CONSTRAINT "sg721s_contract_key"`);
         await queryRunner.query(`ALTER TABLE "tokens" ADD CONSTRAINT "UQ_d1f7114d5c02feb34d82f28112a" UNIQUE ("token_id", "contract_id")`);
-        await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "UQ_2efe151cf3bf9b7872486989da3" UNIQUE ("contract_id", "trait_type", "value")`);
+        await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "UQ_5bb7947574e24559b90b3ebb87e" UNIQUE ("contract_id", "token_id", "trait_type")`);
         await queryRunner.query(`ALTER TABLE "sg721_traits" ADD CONSTRAINT "UQ_b40f9903413f8220b55d7a5f05c" UNIQUE ("contract_id", "trait_type", "value")`);
         await queryRunner.query(`ALTER TABLE "tokens" ADD CONSTRAINT "FK_a09a820642da185ae817a51fc0e" FOREIGN KEY ("contract_id") REFERENCES "sg721s"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "FK_13ac72155a579842fae45cbe80b" FOREIGN KEY ("trait_id") REFERENCES "sg721_traits"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
@@ -23,7 +23,7 @@ export class TokenContract1647631571890 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "FK_13ac72155a579842fae45cbe80b"`);
         await queryRunner.query(`ALTER TABLE "tokens" DROP CONSTRAINT "FK_a09a820642da185ae817a51fc0e"`);
         await queryRunner.query(`ALTER TABLE "sg721_traits" DROP CONSTRAINT "UQ_b40f9903413f8220b55d7a5f05c"`);
-        await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "UQ_2efe151cf3bf9b7872486989da3"`);
+        await queryRunner.query(`ALTER TABLE "token_traits" DROP CONSTRAINT "UQ_5bb7947574e24559b90b3ebb87e"`);
         await queryRunner.query(`ALTER TABLE "tokens" DROP CONSTRAINT "UQ_d1f7114d5c02feb34d82f28112a"`);
         await queryRunner.query(`ALTER TABLE "sg721s" ADD CONSTRAINT "sg721s_contract_key" UNIQUE ("contract")`);
         await queryRunner.query(`ALTER TABLE "token_traits" ADD CONSTRAINT "REL_13ac72155a579842fae45cbe80" UNIQUE ("trait_id")`);

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -19,12 +19,17 @@ export class Repository {
     return await this.db.manager.getRepository(Token).findOne({ where: [{ contract_address: contractId }, { tokenId: tokenId }], relations: ["meta", "traits", "traits.trait"] });
   }
 
+
+  async getTokens(contractId: string, take: number | undefined, skip: number | undefined): Promise<Token[] | undefined> {
+    return await this.db.manager.getRepository(Token).find({ where: [{ contract_address: contractId }], take, skip, relations: ["meta", "traits", "traits.trait"], order: { meta: { score: 'DESC' } } });
+  }
+
   async getContract(contractId: string): Promise<SG721 | undefined> {
-    return await this.db.manager.getRepository(SG721).findOne({ contract: contractId }, { relations: ["meta", "traits"] });
+    return await this.db.manager.getRepository(SG721).findOne({ where: [{ contract: contractId }], relations: ["meta", "traits"] });
   }
 
   async getContracts(take: number | undefined, skip: number | undefined): Promise<SG721[] | undefined> {
-    return await this.db.manager.getRepository(SG721).find({ take, skip, relations: ["meta", "traits"] });
+    return await this.db.manager.getRepository(SG721).find({ take, skip, relations: ["meta", "traits"], order: { createdAt: 'DESC' } });
   }
 
   async createContract(contractId: string): Promise<SG721> {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -16,7 +16,7 @@ export class Repository {
 
 
   async getToken(contractId: string, tokenId: string): Promise<Token | undefined> {
-    return await this.db.manager.getRepository(Token).findOne({ where: [{ contract_address: contractId }, { tokenId: tokenId }], relations: ["meta", "traits", "traits.trait"] });
+    return await this.db.manager.getRepository(Token).findOne({ where: [{ contract_address: contractId }, { tokenId: tokenId }], relations: ["meta", "traits", "traits.trait", "contract.meta"] });
   }
 
 
@@ -48,7 +48,7 @@ export class Repository {
     rankings: Map<string, number>,
   ) {
     const contractRepo = this.db.manager.getRepository(SG721)
-    const c = await contractRepo.findOne({ contract })
+    const c = await contractRepo.findOne({ where: { contract } })
     if (c) {
       const traits = await this.addContractTraits(c, allTraits)
       const tokens = await this.addTokens(c, tokenTraits, scores, rankings)
@@ -68,10 +68,12 @@ export class Repository {
     const tokensRepo = this.db.manager.getRepository(Token)
     const tokenMetaRepo = this.db.manager.getRepository(TokenMeta)
     const tokenTraitsRepo = this.db.manager.getRepository(TokenTrait)
+    const sg721MetaRepo = this.db.manager.getRepository(SG721Meta)
+    const sg721TraitsRepo = this.db.manager.getRepository(SG721Trait)
 
     console.log("Saving sg721 meta")
 
-    const sg721MetaRepo = this.db.manager.getRepository(SG721Meta)
+
     const sg721Meta = sg721MetaRepo.create()
     sg721Meta.contract = contract
     sg721Meta.count = scores.size
@@ -105,7 +107,23 @@ export class Repository {
       tokens.push(token)
     }
     console.log("Saving tokens and the rest")
-    tokensRepo.save(tokens)
+    await tokensRepo.save(tokens)
+
+    console.log("running update")
+    // Update token traits
+    // At some point we should migrate this to typeorm
+    // but I was too lazy
+    const sqlQuery = `
+    UPDATE token_traits t
+      SET    trait_id = s.id
+      FROM   sg721_traits s
+      WHERE  s.trait_type = t.trait_type
+            AND s.value = t.value
+            AND s.contract_id = t.contract_id 
+    `
+    await this.db.manager.query(sqlQuery);
+
+    console.log("Finished persisting")
     return tokens;
   }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -16,7 +16,7 @@ export class Repository {
 
 
   async getToken(contractId: string, tokenId: string): Promise<Token | undefined> {
-    return await this.db.manager.getRepository(Token).findOne({ where: [{ contract: contractId }, { tokenId: tokenId }], relations: ["meta", "traits", "traits.trait"] });
+    return await this.db.manager.getRepository(Token).findOne({ where: [{ contract_address: contractId }, { tokenId: tokenId }], relations: ["meta", "traits", "traits.trait"] });
   }
 
   async getContract(contractId: string): Promise<SG721 | undefined> {
@@ -100,7 +100,6 @@ export class Repository {
       tokens.push(token)
     }
     console.log("Saving tokens and the rest")
-    
     tokensRepo.save(tokens)
     return tokens;
   }


### PR DESCRIPTION
Upgrade typeorm to latest (gives us a nice sorting update)
Add token list endpoint:
```
curl --location --request GET 'http://localhost:3000/contracts/stars18a0pvw326fydfdat5tzyf4t8lhz0v6fyfaujpeg07fwqkygcxejsnp5fac/rarities'
```

Clean up schema. I think we should still audit the schema, I couldn't figure out how to link TokenTrait -> SG721Trait (if we even care about that.

* probably need to run migrations.

*Last minute update. Added a somewhat hacky pure SQL query to update the trait ids so we can get counts returned with the tokens. This should be enough to calculate the per-trait rarities on a single token call

`{{host}}/contracts/stars18a0pvw326fydfdat5tzyf4t8lhz0v6fyfaujpeg07fwqkygcxejsnp5fac/rarities/8`

Was able to use `class-transformer` to get nicer output
```json
{
    "tokenId": "2",
    "score": 1139.2560751222434,
    "rank": 173,
    "traits": [
        {
            "traitType": "Color Base",
            "value": "Reds",
            "count": 137
        },
        {
            "traitType": "Color Focused",
            "value": "No",
            "count": 846
        },
        {
            "traitType": "Dark Interior",
            "value": "Yes",
            "count": 401
        },
        {
            "traitType": "Shape Repetition",
            "value": "Yes",
            "count": 945
        },
        {
            "traitType": "Shape Type",
            "value": "Donut",
            "count": 166
        },
        {
            "traitType": "Color Model",
            "value": "Saturated Depth",
            "count": 513
        },
        {
            "traitType": "Repetitions",
            "value": "0.5",
            "count": 64
        },
        {
            "traitType": "Seed",
            "value": "1766",
            "count": 1
        },
        {
            "traitType": "Color Offset",
            "value": "4.2",
            "count": 13
        }
    ]
}
```