### PR TITLE
Refresh lambda

### DIFF
--- a/metadata.ts
+++ b/metadata.ts
@@ -1,10 +1,7 @@
 import { Context, Handler } from 'aws-lambda';
-import { QueryContract } from "./src/cosmwasm/sg721";
-import { defaultConfig } from "./src/config";
-import { downloadMetadata } from "./src/metadata/download";
-import { Repository } from './src/repository';
-import { getServicesSingleton } from './src/services';
 import { ContractMessage } from "./src/message";
+import { downloadMetadata } from "./src/metadata/download";
+import { getServicesSingleton } from './src/services';
 
 const region = process.env.AWS_REGION
 

--- a/metadata.ts
+++ b/metadata.ts
@@ -6,24 +6,24 @@ import { getServicesSingleton } from './src/services';
 const region = process.env.AWS_REGION
 
 export const handler: Handler = async (event: any, context: Context) => {
-    if(process.env.SLS_OFFLINE){
+    if (process.env.SLS_OFFLINE) {
         event = JSON.parse(event.body)
     }
-    if(!event?.Records?.length) {
+    if (!event?.Records?.length) {
         console.log("No records found")
         return
     }
     const eventRecord = event.Records[0].Sns
-    console.log("EVENT",JSON.stringify(eventRecord))
-    console.log("CONTEXT",context)
+    console.log("EVENT", JSON.stringify(eventRecord))
+    console.log("CONTEXT", context)
     console.log('parsing event message', eventRecord.Message)
     const message = JSON.parse(eventRecord.Message) as ContractMessage
-    
+
     // const contractId = 'stars1ltd0maxmte3xf4zshta9j5djrq9cl692ctsp9u5q0p9wss0f5lmsvd9ukk'
     // const contractId = 'stars18a0pvw326fydfdat5tzyf4t8lhz0v6fyfaujpeg07fwqkygcxejsnp5fac'//stew
     const { contractId } = message
     console.log('Processing contract', contractId)
-    const metadata = await downloadMetadata(contractId)    
+    const metadata = await downloadMetadata(contractId)
     const services = await getServicesSingleton()
     const output = await services.repo.persistIngestedData(
         contractId,
@@ -33,9 +33,12 @@ export const handler: Handler = async (event: any, context: Context) => {
         metadata.rankings,
         metadata.mintedTokens,
         metadata.numTokens
-        )
+    )
+
+    await services.repo.setRefreshTimestamp(contractId)
+
     return {
-        statusCode:200,
-        body: JSON.stringify({traits:output.traits.length, tokens:output.tokens.length})
+        statusCode: 200,
+        body: JSON.stringify({ traits: output.traits.length, tokens: output.tokens.length })
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "cosmwasm": "^1.0.3",
+    "parse-duration": "^1.0.2",
     "pg": "^8.7.3",
     "retry-axios": "^2.6.0",
     "tiny-async-pool": "^1.2.0",

--- a/refresher.ts
+++ b/refresher.ts
@@ -4,6 +4,7 @@ import {  instanceToPlain, plainToClass } from "class-transformer";
 import { SG721Model } from './src/api/models/sg721.model';
 import parse from 'parse-duration'
 import {publishSnsTopic} from "./src/sns"
+import { createContractMessage } from './src/message';
 
 const refreshInterval = process.env.REFRESH_FREQUENCY
 
@@ -16,9 +17,8 @@ export const handler: Handler = async (event: any, context: Context) => {
     // let's just make sure we have a valid interval
     if (parse(refreshInterval) > 0) {
         const contracts = await services.repo.getContractsToRefresh(refreshInterval)
-        await services.repo.refreshContracts(contracts)
         contracts.forEach((c) => {
-            publishSnsTopic({contractId:c.id})
+            publishSnsTopic(createContractMessage(c.contract))
         })
         
         return await JSON.stringify(instanceToPlain(plainToClass(SG721Model, contracts)))

--- a/refresher.ts
+++ b/refresher.ts
@@ -1,0 +1,28 @@
+import { Context, Handler } from 'aws-lambda';
+import { getServicesSingleton } from './src/services';
+import {  instanceToPlain, plainToClass } from "class-transformer";
+import { SG721Model } from './src/api/models/sg721.model';
+import parse from 'parse-duration'
+import {publishSnsTopic} from "./src/sns"
+
+const refreshInterval = process.env.REFRESH_FREQUENCY
+
+export const handler: Handler = async (event: any, context: Context) => {
+    // console.log(event, context)
+    // console.log(process.env)
+    // console.log(refreshInterval)
+    const services = await getServicesSingleton()
+
+    // let's just make sure we have a valid interval
+    if (parse(refreshInterval) > 0) {
+        const contracts = await services.repo.getContractsToRefresh(refreshInterval)
+        await services.repo.refreshContracts(contracts)
+        contracts.forEach((c) => {
+            publishSnsTopic({contractId:c.id})
+        })
+        
+        return await JSON.stringify(instanceToPlain(plainToClass(SG721Model, contracts)))
+    } else {
+        throw new Error(`invalid interval received ${refreshInterval}`)
+    }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,7 @@ custom:
         (cd .serverless/stargaze-rarity/ && zip -q -FSr ../stargaze-rarity.zip .)     && printf ".\n" &&
         rm -rf .serverless/stargaze-rarity/ &&
         printf "[after:package:createDeploymentArtifacts hook] Done\n"
+  refreshFrequency: 30 minutes
 
 provider:
   name: aws
@@ -41,22 +42,23 @@ provider:
         identitySource:
           - $request.header.Authorization 
         type: request
-    # https://www.serverless.com/framework/docs/providers/aws/events/http-api#jwt-authorizers
-
-#  vpc: 
-#    securityGroupIds: 
-#      - sg-60fddd05
-#    subnetIds:
-#      - subnet-31f0920b
-#      - subnet-8b32c0d2
-#      - subnet-b55585c2
-#      - subnet-c75510a2
-#      - subnet-139c8e3b
-#      - subnet-66bc2e6a         
+    # https://www.serverless.com/framework/docs/providers/aws/events/http-api#jwt-authorizers    
 
 functions:
   basicAuth:
     handler: auth.handler
+  refresher:
+    handler: refresher.handler
+    environment:
+      REFRESH_FREQUENCY: ${self:custom.refreshFrequency}
+    events:
+      - schedule: rate(${self:custom.refreshFrequency})
+      - httpApi:
+          path: /contracts/refresh
+          method: put
+          authorizer:
+            name: basicAuth
+            type: request
   api:
     timeout: 20
     handler: api.handler

--- a/src/api/models/sg721.model.ts
+++ b/src/api/models/sg721.model.ts
@@ -12,6 +12,9 @@ export class SG721Model {
 
   createdAt: Date;
 
+  @Exclude()
+  lastRefreshed: Date;
+
   @Expose()
   @Type(() => Number)
   @Transform(({obj}) => obj?.meta?.count, {toClassOnly: true})

--- a/src/database/entities/sg721.entity.ts
+++ b/src/database/entities/sg721.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn, Unique } from "typeorm";
+import { Column, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn, Unique, UpdateDateColumn } from "typeorm";
 import { SG721Trait } from "./sg721Trait.entity";
 import { Token } from "./token.entity";
 import { SG721Meta } from "./sg721Meta.entity";
@@ -19,6 +19,13 @@ export class SG721 {
 
   @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
   createdAt: Date;
+
+  @Column({
+    type: "timestamp",
+    nullable: true,
+    name: 'last_refreshed' 
+  })
+  lastRefreshed: Date;
 
   @OneToMany(() => SG721Trait, trait => trait.contract)
   traits: SG721Trait[];

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,5 +1,5 @@
 import { SG721 } from "./database/entities/sg721.entity";
-import { DataSource, In } from "typeorm";
+import { DataSource, In, UpdateResult } from "typeorm";
 import { ExtTrait, TraitValue } from "./database/utils/types";
 import { SG721Trait } from "./database/entities/sg721Trait.entity";
 import { Token } from "./database/entities/token.entity";
@@ -19,7 +19,7 @@ export class Repository {
   constructor(db: DataSource) {
     this.db = db;
   }
-  
+
   async getToken(contractId: string, tokenId: string): Promise<Token | undefined> {
     return await this.db.manager.getRepository(Token).findOne({
       where: [{
@@ -75,7 +75,7 @@ export class Repository {
     scores: Map<string, number>,
     rankings: Map<string, number>,
     mintedTokens: string[],
-    numTokens:number
+    numTokens: number
   ) {
     try {
       const contractRepo = this.db.manager.getRepository(SG721)
@@ -88,7 +88,7 @@ export class Repository {
           tokens
         }
       }
-    }catch (e) {
+    } catch (e) {
       console.log('cannot save to db', e)
       throw e
     }
@@ -115,7 +115,7 @@ export class Repository {
     sg721Meta.contract = contract
     sg721Meta.count = numTokens
     sg721Meta.minted = mintedTokens.length
-    
+
     await saveChunked(sg721MetaRepo, SG721Meta, [sg721Meta], '"sg721_meta_unique_contract"', false,
       `count = EXCLUDED.count,
        minted = EXCLUDED.minted
@@ -133,7 +133,7 @@ export class Repository {
       const traits = extTraits.map((t) => {
         const tokenTrait = tokenTraitsRepo.create()
         tokenTrait.traitType = t.trait_type
-        tokenTrait.value = {v: t.value}
+        tokenTrait.value = { v: t.value }
         tokenTrait.token = token
         tokenTrait.contract = contract
         return tokenTrait
@@ -157,13 +157,13 @@ export class Repository {
     for (i = 0, j = tokens.length; i < j; i += chunkSize) {
       let chunk = tokens.slice(i, i + chunkSize);
 
-      chunk = Array.from(chunk.reduce((map,curr)=>{
-        const key =curr.tokenId
+      chunk = Array.from(chunk.reduce((map, curr) => {
+        const key = curr.tokenId
         map.set(key, curr)
         return map;
-      }, new Map<string,Token>()).values())
+      }, new Map<string, Token>()).values())
       await saveChunked(tokensRepo, Token, chunk, '"token_unique_id_contract"', true, undefined, chunkSize)
-      const tokenWithId = await tokensRepo.find({where: {tokenId: In(chunk.map(t => t.tokenId))}})
+      const tokenWithId = await tokensRepo.find({ where: { tokenId: In(chunk.map(t => t.tokenId)) } })
       const idMap = tokenWithId.reduce((acc, t) => {
         acc[t.tokenId] = t.id
         return acc
@@ -171,12 +171,12 @@ export class Repository {
       for (let token of tokens) {
         token.id = idMap[token.tokenId]
       }
-      
-      let metas = Array.from(chunk.map((t)=>t.meta).reduce((map,curr)=>{
-        const key =curr.token.tokenId
+
+      let metas = Array.from(chunk.map((t) => t.meta).reduce((map, curr) => {
+        const key = curr.token.tokenId
         map.set(key, curr)
         return map;
-      }, new Map<string,TokenMeta>()).values())
+      }, new Map<string, TokenMeta>()).values())
       await saveChunked(tokenMetaRepo, TokenMeta, metas, '"token_meta_unique_token_contract"', false,
         `
         rank = EXCLUDED.rank, 
@@ -189,11 +189,11 @@ export class Repository {
         EXCLUDED.score)`,
         chunkSize)
 
-      let traits = Array.from(chunk.map(t => t.traits).flat().reduce((map,curr)=>{
+      let traits = Array.from(chunk.map(t => t.traits).flat().reduce((map, curr) => {
         const key = curr.token.tokenId + curr.traitType
         map.set(key, curr)
         return map;
-      }, new Map<string,TokenTrait>()).values())
+      }, new Map<string, TokenTrait>()).values())
       await saveChunked(tokenTraitsRepo, TokenTrait, traits, '"token_traits_contract_token_trait_type_unique"', false,
         `
         value = EXCLUDED.value 
@@ -238,17 +238,36 @@ export class Repository {
         traits.push(trait)
       }
     }
-    const uniqueTraits = traits.reduce((map,curr)=>{
-      const key =curr.traitType+JSON.stringify(curr.value);
+    const uniqueTraits = traits.reduce((map, curr) => {
+      const key = curr.traitType + JSON.stringify(curr.value);
       map.set(key, curr)
       return map;
-    }, new Map<string,SG721Trait>())
+    }, new Map<string, SG721Trait>())
 
-    const uniq=Array.from(uniqueTraits.values());
+    const uniq = Array.from(uniqueTraits.values());
     await saveChunked(traitsRepo, SG721Trait, uniq, '"sg721_traits_unique"', false, `
     count = EXCLUDED.count
       WHERE (sg721_traits.count) is distinct from (EXCLUDED.count)`, 500)
     // await traitsRepo.insert(traits);
     return uniq;
+  }
+
+  async getContractsToRefresh(interval: string): Promise<SG721[]> {
+    const contracts = await this.db.manager.getRepository(SG721)
+      .createQueryBuilder("sg721")
+      // Possibly dangerous, but I couldn't figure out the variable replacement
+      .where(`coalesce(sg721.last_refreshed, now() - interval '${interval}') <= now() - interval '${interval}'`)
+      .getMany();
+    console.log(contracts)
+    return contracts
+  }
+
+  async refreshContracts(contracts: SG721[]): Promise<UpdateResult> {
+    return await this.db.manager.getRepository(SG721)
+      .createQueryBuilder()
+      .update(SG721)
+      .set({ lastRefreshed: new Date() })
+      .whereInIds(contracts.map((c) => c.id))
+      .execute();
   }
 }

--- a/src/sns.ts
+++ b/src/sns.ts
@@ -1,0 +1,24 @@
+import { PublishCommand, PublishCommandInput, SNSClient } from "@aws-sdk/client-sns";
+
+const { AWS_REGION: region, IS_OFFLINE: isOffline, METADATA_TOPIC_ARN: snsTopic } = process.env
+const snsClient = new SNSClient({ region });
+
+export const publishSnsTopic = async (data) => {
+  try {
+    if (!isOffline && snsTopic) {
+      const params: PublishCommandInput = {
+        Message: JSON.stringify(data),
+        TopicArn: snsTopic
+      }
+      const command = new PublishCommand(params);
+      const result = await snsClient.send(command)
+      return result
+    }
+    else {
+      console.log("No SNS messages sent in offline mode")
+    }
+
+  } catch (err) {
+    console.log("Error", err.stack);
+  }
+}


### PR DESCRIPTION
Adds a new lambda that queries the DB to find collections that are still in mint progress. It maintains a `last_refreshed` field in the DB to track the last time metadata was pulled. Collections where `minted < total` are candidates. So that we don't re-refresh too quickly it checks the lambda schedule frequency against the `last_refreshed` and fires off events for those.

It can be manually triggered with
```
curl --location --request PUT 'http://localhost:3000/contracts/refresh' \
--header 'Authorization: Basic ...'
```