### PR TITLE
K6 Load test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "cosmwasm": "^1.0.3",
+    "k6": "^0.0.0",
     "parse-duration": "^1.0.2",
     "pg": "^8.7.3",
     "retry-axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@aws-sdk/client-sns": "^3.54.1",
     "@types/dotenv": "^8.2.0",
+    "@types/k6": "^0.36.0",
     "axios": "^0.26.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
@@ -22,7 +23,9 @@
     "deploy": " NODE_ENV=production sls deploy",
     "deployProd": " NODE_ENV=production sls deploy --stage prod",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
-    "query": "npx cosmwasm --init scripts/query.ts"
+    "query": "npx cosmwasm --init scripts/query.ts",
+    "loadTestProd": "HOST=https://api.howrare.world/v1 k6 run --vus 5 --duration 200s ./test/loadTests.js",
+    "loadTestProdDebug": "HOST=https://api.howrare.world/v1 k6 run --http-debug ./test/loadTests.js"
   },
   "devDependencies": {
     "@cosmjs/cli": "^0.28.0",

--- a/test/contract.ts
+++ b/test/contract.ts
@@ -1,7 +1,0 @@
-import http from 'k6/http';
-
-export default function() {
-  for (let id = 1; id <= 100; id++) {
-    http.get(http.url`http://example.com/posts/${id}`);
-  }
-}

--- a/test/contract.ts
+++ b/test/contract.ts
@@ -1,0 +1,7 @@
+import http from 'k6/http';
+
+export default function() {
+  for (let id = 1; id <= 100; id++) {
+    http.get(http.url`http://example.com/posts/${id}`);
+  }
+}

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,174 @@
+const fixtures = {
+    contracts: [
+        {
+            "contract": "stars156x86uprzaj04v7qwnpl8djj5jws3gn73jz08qkydmkd0c0lp6gqv575pm",
+            "createdAt": "2022-03-25T19:45:44.180Z",
+            "count": 9000,
+            "minted": 1385,
+            "lastRefreshed": "2022-03-28T10:52:51.404Z"
+        },
+        {
+            "contract": "stars17ptevgk0rr06mctweh66mq54ywq62yjllwh5sg0e0f3mr5sta0zqmmu0z6",
+            "createdAt": "2022-03-25T19:45:34.299Z",
+            "count": 10000,
+            "minted": 1662,
+            "lastRefreshed": "2022-03-28T10:53:11.573Z"
+        },
+        {
+            "contract": "stars18p7lhcxl3ac85ke52u4h7mmzkv5pk5jl6lpgk2sp73a0cw3u0c5qau8wku",
+            "createdAt": "2022-03-25T19:45:23.783Z",
+            "count": 5632,
+            "minted": 777,
+            "lastRefreshed": "2022-03-28T10:53:04.478Z"
+        },
+        {
+            "contract": "stars10v8m3lglw4vat5g3w4xj7ven7puxudnqkjwwaf9nh3alukxpmh3qm4wzwh",
+            "createdAt": "2022-03-25T19:45:11.856Z",
+            "count": 314,
+            "minted": 314,
+            "lastRefreshed": "2022-03-25T19:49:36.336Z"
+        },
+        {
+            "contract": "stars1yw4xvtc43me9scqfr2jr2gzvcxd3a9y4eq7gaukreugw2yd2f8tssqyvcm",
+            "createdAt": "2022-03-25T15:58:35.939Z",
+            "count": 999,
+            "minted": 999,
+            "lastRefreshed": "2022-03-25T17:31:37.813Z"
+        },
+        {
+            "contract": "stars1r57m20afwdhkwy67520p8vzdchzecesmlmc8k8w2z7t3h9aevjvsxwdluc",
+            "createdAt": "2022-03-25T15:58:00.599Z",
+            "count": 400,
+            "minted": 400,
+            "lastRefreshed": "2022-03-25T10:41:11.388Z"
+        },
+        {
+            "contract": "stars1m4ns69zvkk2zv0946mw298tlky5ckvu08rtxggtg29p784kc5sxqwgx4h0",
+            "createdAt": "2022-03-25T15:56:52.619Z",
+            "count": 6000,
+            "minted": 6000,
+            "lastRefreshed": "2022-03-25T17:32:56.296Z"
+        },
+        {
+            "contract": "stars1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whqnm7uc2",
+            "createdAt": "2022-03-25T15:54:35.078Z",
+            "count": 500,
+            "minted": 500,
+            "lastRefreshed": "2022-03-25T17:31:22.279Z"
+        },
+        {
+            "contract": "stars1fka7t9avjmx7yphqxn3lzy3880tgcc0wu23xwfwxe5e5y3lkmzfq3ne5gp",
+            "createdAt": "2022-03-25T15:54:32.112Z",
+            "count": 625,
+            "minted": 625,
+            "lastRefreshed": "2022-03-25T17:32:49.165Z"
+        },
+        {
+            "contract": "stars12njsx22ne73swjqxxn5e7xtc2n95y2aw8r73cqdth0g86way24cq98v5q7",
+            "createdAt": "2022-03-25T15:52:19.219Z",
+            "count": 641,
+            "minted": 641,
+            "lastRefreshed": "2022-03-25T17:31:36.313Z"
+        },
+        {
+            "contract": "stars17s7emulfygjuk0xn906athk5e5efsdtumsat5n2nad7mtrg4xres3ysf3p",
+            "createdAt": "2022-03-25T15:27:59.964Z",
+            "count": 8888,
+            "minted": 8888,
+            "lastRefreshed": "2022-03-25T17:35:54.028Z"
+        },
+        {
+            "contract": "stars1nzvd5njkc0gqdezgzzqw00tu056rgxgwaqgq25g9ku0y5au3nwmq6flhtj",
+            "createdAt": "2022-03-22T03:34:39.085Z",
+            "count": 28,
+            "minted": 28,
+            "lastRefreshed": "2022-03-25T17:31:28.694Z"
+        },
+        {
+            "contract": "stars1w9udhqtvuefwfmx7af9qe5jjhmrjk4p7ezxm6py08puykgen6uhqfft0xv",
+            "createdAt": "2022-03-22T03:34:31.852Z",
+            "count": 1111,
+            "minted": 1111,
+            "lastRefreshed": "2022-03-25T17:35:24.832Z"
+        },
+        {
+            "contract": "stars12cvr4t3rqdl5d90p3qsdq2ej8dte5k4gdsxs6uccmzq4h2307nfq2lruvz",
+            "createdAt": "2022-03-22T03:34:25.961Z",
+            "count": 25,
+            "minted": 25,
+            "lastRefreshed": "2022-03-25T17:31:14.240Z"
+        },
+        {
+            "contract": "stars19jq6mj84cnt9p7sagjxqf8hxtczwc8wlpuwe4sh62w45aheseues57n420",
+            "createdAt": "2022-03-22T03:34:10.855Z",
+            "count": 9999,
+            "minted": 9999,
+            "lastRefreshed": "2022-03-25T18:11:52.259Z"
+        },
+        {
+            "contract": "stars1l6ut7ymdzhf38wldp0eu6ccjawgvzku69kmjl6ddjqpcm9f62gkq3h4a6p",
+            "createdAt": "2022-03-22T03:33:13.560Z",
+            "count": 88,
+            "minted": 88,
+            "lastRefreshed": "2022-03-25T17:31:15.469Z"
+        },
+        {
+            "contract": "stars1t3f4zxve6725sf4glrnlar8uku78j0nyfl0ppzgfju9ft9phvqwq47have",
+            "createdAt": "2022-03-22T03:32:55.057Z",
+            "count": 1111,
+            "minted": 1111,
+            "lastRefreshed": "2022-03-25T17:32:03.720Z"
+        },
+        {
+            "contract": "stars1zvjnc08uy0zz43m0nlh9f5aetpa3amn6a034yqvmsgvzshk9cldsdhqjzg",
+            "createdAt": "2022-03-22T03:30:53.232Z",
+            "count": 888,
+            "minted": 888,
+            "lastRefreshed": "2022-03-25T17:31:38.322Z"
+        },
+        {
+            "contract": "stars14sa4u42n2a8kmlvj3qcergjhy6g9ps06rzeth94f2y6grlat6u6sv9y4pd",
+            "createdAt": "2022-03-22T03:14:18.123Z",
+            "count": 8128,
+            "minted": 8128,
+            "lastRefreshed": "2022-03-25T17:34:08.514Z"
+        },
+        {
+            "contract": "stars1n08lr7w2tkpd8m79hmt3ex7076awk77qysdzlg70a35agwzznwzqwgfq0j",
+            "createdAt": "2022-03-22T03:06:06.794Z",
+            "count": 42,
+            "minted": 42,
+            "lastRefreshed": "2022-03-25T17:31:14.919Z"
+        },
+        {
+            "contract": "stars1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsu9n0cj",
+            "createdAt": "2022-03-22T02:31:43.049Z",
+            "count": 4840,
+            "minted": 4840,
+            "lastRefreshed": "2022-03-25T17:33:00.098Z"
+        },
+        {
+            "contract": "stars15pqspe0lcyeztwmk232vkwqgpklku5t74du00827l44p4vxnal7qvevcuw",
+            "createdAt": "2022-03-22T02:30:41.048Z",
+            "count": 5000,
+            "minted": 5000,
+            "lastRefreshed": "2022-03-25T17:33:06.841Z"
+        },
+        {
+            "contract": "stars1ltd0maxmte3xf4zshta9j5djrq9cl692ctsp9u5q0p9wss0f5lmsvd9ukk",
+            "createdAt": "2022-03-22T02:15:19.919Z",
+            "count": 5000,
+            "minted": 5000,
+            "lastRefreshed": "2022-03-25T17:39:07.207Z"
+        },
+        {
+            "contract": "stars18a0pvw326fydfdat5tzyf4t8lhz0v6fyfaujpeg07fwqkygcxejsnp5fac",
+            "createdAt": "2022-03-22T02:14:59.711Z",
+            "count": 1024,
+            "minted": 1024,
+            "lastRefreshed": "2022-03-25T17:31:28.502Z"
+        }
+    ]
+}
+
+export { fixtures }

--- a/test/loadTests.js
+++ b/test/loadTests.js
@@ -1,0 +1,34 @@
+import http from 'k6/http';
+import { group } from 'k6';
+import { fixtures } from './fixtures.js';
+
+export default function () {
+
+  const { HOST } = __ENV
+
+  // Read Contract
+  fixtures.contracts.forEach((c) => {
+    http.get(http.url`${HOST}/contracts/${c.contract}`);
+  })
+  const pages = [...Array(10).keys()]
+
+  // List Contracts
+  pages.forEach((page) => {
+    http.get(http.url`${HOST}/contracts?page=${page}`);
+  })
+
+  // Read Tokens
+  fixtures.contracts.forEach((c) => {
+    // Note: This may result in 404 if the mints were out of order
+    const maxIterations = Math.min(c.minted, 10)
+    for (let i = 1; i < maxIterations; i++) {
+      http.get(http.url`${HOST}/contracts/${c.contract}/rarities/${i}`);
+    }
+  })
+
+  // List Tokens
+  fixtures.contracts.forEach((c) => {
+    http.get(http.url`${HOST}/contracts/${c.contract}/rarities`);
+  })
+
+}


### PR DESCRIPTION
This adds a simple load test.
`npm i`
Then
`npm run loadTestProd`
This tests the `GET` endpoints only and does a simple loop through a few contracts. We can adjust the `VUs` in the script to add more load.